### PR TITLE
fix: :bug: correc the typo

### DIFF
--- a/app/styles/MediumModuleStyles.js
+++ b/app/styles/MediumModuleStyles.js
@@ -7,7 +7,7 @@ export default class MediumModuleStyles extends MediumCoreStyles {
       /**************************************************
        * Using defaultUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder  },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XLargeModuleStyles.js
+++ b/app/styles/XLargeModuleStyles.js
@@ -7,7 +7,7 @@ export default class XLargeModuleStyles extends XLargeCoreStyles {
       /**************************************************
        * Using XLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder  },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }

--- a/app/styles/XXLargeModuleStyles.js
+++ b/app/styles/XXLargeModuleStyles.js
@@ -7,7 +7,7 @@ export default class XXLargeModuleStyles extends XXLargeCoreStyles {
       /**************************************************
        * Using XXLargeUtilityStyles example
        *************************************************/
-      testWrappidStyleClass: { ...this.style.devBorder  },
+      testWrappidStyleClass: { ...this.style.devBorder },
     };
   }
 }


### PR DESCRIPTION
correct the typo in following files MediumModulesStyles.js, XLargeModuleStyles.js and XXLargeModuleStyles.js from 'styles' to style

ref: #15

## Description

Clearly describe the changes you've made in this pull request. Explain the purpose and reasoning behind the changes. Reference any relevant issues or discussions using keywords like "Fixes #<issue_number>" or "Resolves #<issue_number>".

## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
